### PR TITLE
feat: Smarter Date Filter Defaults (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-11-26
+
+### Changed
+- Improved "Filter by date" UX: Now defaults to a 6-month range (6 months ago to today) instead of just the current month when enabled. This provides immediate historical context without requiring manual adjustment.
+
 ## [1.1.1] - 2025-11-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The "VDC Vault Data Exporter" extension should now appear in your list of extens
 2. **Navigate to VDC Vault:** Go to any Veeam Data Cloud **Vault** page (organization dashboard, tenant management, or specific tenant page). **Important:** This extension only works on Vault service pages - if you're on other VDC services, the extension will display a message indicating it's not active on those services.
 3. **Open the Extension:** Click the extension's icon in the Chrome toolbar. You may need to click the puzzle piece icon first to find and "pin" it.
 4. **Configure Export (Optional):**
-   - Check **"Filter by date"** to export only specific months of Vault usage data
+   - Check **"Filter by date"** to export only specific months of Vault usage data (defaults to last 6 months)
    - Check **"Tenants summary only"** for a fast export without detailed vault statistics
 5. **Start Export:** Click the **Export to CSV** or **Export Tenant to CSV** button (text varies based on context).
 6. **Save the File:** The extension will fetch the Vault data (watch the progress indicator). Once complete, a "Save As" dialog will appear with an automatically generated filename like `veeam_data_cloud_vault_export_2025-10-03.csv`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Veeam Data Cloud Vault Exporter",
   "short_name": "VDC Vault Exporter",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Exports Veeam Data Cloud Vault data to CSV.",
   "icons": {
     "16": "icon-16.png",

--- a/popup.js
+++ b/popup.js
@@ -197,9 +197,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const toMonth = String(now.getMonth() + 1).padStart(2, '0');
       const toDateStr = `${toYear}-${toMonth}`;
 
-      // Calculate 6 months ago (From Date)
+      // Calculate start of 6 month window (From Date)
       const past = new Date();
-      past.setMonth(now.getMonth() - 6);
+      past.setMonth(now.getMonth() - 5);
       const fromYear = past.getFullYear();
       const fromMonth = String(past.getMonth() + 1).padStart(2, '0');
       const fromDateStr = `${fromYear}-${fromMonth}`;

--- a/popup.js
+++ b/popup.js
@@ -191,16 +191,24 @@ document.addEventListener('DOMContentLoaded', () => {
     if (e.target.checked) {
       dateInputsDiv.style.display = 'block';
 
-      // Get the current date
+      // Get the current date (To Date)
       const now = new Date();
-      const year = now.getFullYear();
-      // getMonth() is 0-indexed (0=Jan), so we add 1
-      const month = String(now.getMonth() + 1).padStart(2, '0'); 
-      const currentMonth = `${year}-${month}`;
+      const toYear = now.getFullYear();
+      const toMonth = String(now.getMonth() + 1).padStart(2, '0');
+      const toDateStr = `${toYear}-${toMonth}`;
+
+      // Calculate 6 months ago (From Date)
+      const past = new Date();
+      past.setMonth(now.getMonth() - 6);
+      const fromYear = past.getFullYear();
+      const fromMonth = String(past.getMonth() + 1).padStart(2, '0');
+      const fromDateStr = `${fromYear}-${fromMonth}`;
 
       // Set the date on both flatpickr instances
-      dateFromPicker.setDate(currentMonth, true); // true triggers the onChange event
-      dateToPicker.setDate(currentMonth, true);
+      // Set From date first
+      dateFromPicker.setDate(fromDateStr, true); 
+      // Set To date second
+      dateToPicker.setDate(toDateStr, true);
 
     } else {
       dateInputsDiv.style.display = 'none';


### PR DESCRIPTION
## Summary
This PR improves the user experience of the "Filter by date" feature.

## Changes
- **UX Improvement**: When enabling the date filter, the range now defaults to **[6 Months Ago -> Today]** instead of **[Current Month -> Current Month]**.
- This provides immediate historical context for users without needing to manually adjust the "From" date every time.
- Bumped version to `1.2.0`.
- Updated `CHANGELOG.md` and `README.md`.

## Testing
- Verified that checking "Filter by date" correctly sets the "From" date to 6 months in the past.
- Verified that the "To" date is set to the current month.

Closes #3 